### PR TITLE
Fix app install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,9 @@ test:
 		echo "A single arm64-v8a device must be attached via adb to run tests"; \
 		exit 1; \
 	fi
+	@if adb shell pm list packages $(PKG_NAME) | grep -q $(PKG_NAME); then \
+		adb uninstall $(PKG_NAME); \
+	fi
 	@for cmd in $(TEST_COMMANDS); do \
 		eval $$cmd; \
 		ret=$$?; \

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ untested.
 
 ## Supported Android Versions
 
-Bungeegum has been tested successfully on Android 7, 9, 11, and 12.
+Bungeegum has been tested successfully on Android 7, 9 - 13.
 
 ## Usage
 

--- a/python/src/bungeegum/bg.py
+++ b/python/src/bungeegum/bg.py
@@ -118,7 +118,7 @@ def install_and_attach(
         logging.info("App package not installed. Attempting to install...")
         ref = pkg_resources.files("bungeegum") / apk_path
         with pkg_resources.as_file(ref) as path:
-            device.install(str(path))
+            device.install(str(path), flags=["-r", "-t", "-g"])
         time.sleep(5)  # Give some time for the package manager to finish its work
 
     retry_count = 0


### PR DESCRIPTION
The app now installs with all permissions granted (-g), this change enables operation on Android 13. The test Makefile target has been updated to perform an uninstall if the Bungeegum app is already installed.

Bungeegum has been tested successfully on the following devices:

 * Pixel 7a [Google Pixel 7a (lynx)] @ 13 arm64-v8a
 * SM-A217F [Samsung Galaxy A21s] @ 10 arm64-v8a
 * SM-G970F [Samsung Galaxy S10e] @ 9 arm64-v8a

Closes #1 