### PR TITLE
Confirm Android 8 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Other distributions and Python versions may work, but are currently untested.
 
 ## Supported Android Versions
 
-Bungeegum has been tested successfully on Android 7, 9 - 13.
+Bungeegum has been tested successfully on Android 7 - 13.
 
 ## Usage
 


### PR DESCRIPTION
`make test` has run successfully on a Nexus 6P [Huawei angler?] @ 8.1.0 arm64-v8a